### PR TITLE
hydralit_components 1.0.10 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "hydralit_components" %}
+{% set version = "1.0.10" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: aeae8c9531451a5b93df9f4df208b4cb159b1a0ccf523f2a45d633e64b700496
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+    - bs4
+  run:
+    - bs4
+    - lxml
+    - python
+    - streamlit >=1.7
+
+test:
+  imports:
+    - hydralit_components
+    - hydralit_components.CookieManager
+    - hydralit_components.Experimental
+    - hydralit_components.InfoCard
+    - hydralit_components.Loaders
+    - hydralit_components.NavBar
+    - hydralit_components.OptionBar
+    - hydralit_components.ProgressBar
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/tanglespace/hydralit_components
+  license: Apache 2
+  license_family: APACHE
+  license_file: 
+  summary: Components to use with or without the Hydralit package.
+  doc_url: 
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - psteyer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,11 +9,14 @@ source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
   sha256: aeae8c9531451a5b93df9f4df208b4cb159b1a0ccf523f2a45d633e64b700496
   patches:
+    # upstream refers to beautifulsoup4 as bs4, which caused test failures for pip check
     - patches/0001-bs4-to-beautifulsoup4.patch
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  # s390x is missing streamlit
+  skip: true  # [py<36 or s390x]
 
 requirements:
   build:
@@ -24,7 +27,6 @@ requirements:
     - python
     - setuptools
     - wheel
-    - bs4
   run:
     - bs4
     - lxml
@@ -48,12 +50,12 @@ test:
 
 about:
   home: https://github.com/tanglespace/hydralit_components
-  license: Apache 2
+  license: Apache-2.0
   license_family: APACHE
-  license_file: 
+  license_file: LICENSE
   summary: Components to use with or without the Hydralit package.
-  doc_url: 
-  dev_url: 
+  doc_url: https://github.com/TangleSpace/hydralit_components/blob/main/README.md
+  dev_url: https://github.com/TangleSpace/hydralit_components
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,12 +8,17 @@ package:
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
   sha256: aeae8c9531451a5b93df9f4df208b4cb159b1a0ccf523f2a45d633e64b700496
+  patches:
+    - patches/0001-bs4-to-beautifulsoup4.patch
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
+  build:
+    - patch       # [not win]
+    - m2-patch    # [win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ about:
   license_family: APACHE
   license_file: LICENSE
   summary: Components to use with or without the Hydralit package.
+  description: Components to use with or without the Hydralit package.
   doc_url: https://github.com/TangleSpace/hydralit_components/blob/main/README.md
   dev_url: https://github.com/TangleSpace/hydralit_components
 

--- a/recipe/patches/0001-bs4-to-beautifulsoup4.patch
+++ b/recipe/patches/0001-bs4-to-beautifulsoup4.patch
@@ -1,0 +1,25 @@
+From 943accd5fdcd598440539f2b2318e67338025e91 Mon Sep 17 00:00:00 2001
+From: Udo-Peter Steyer <ous8292@gmail.com>
+Date: Mon, 29 Apr 2024 16:37:36 -0500
+Subject: [PATCH] bs4 to beautifulsoup4
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 3aa8ae3..f8bfd7b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -33,7 +33,7 @@ setuptools.setup(
+     install_requires=[
+         'streamlit>=1.7',
+         'lxml',
+-        'bs4'
++        'beautifulsoup4'
+     ],
+     python_requires='>=3.6',
+     keywords=[
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
hydralit_components 1.0.10 :snowflake:

**Destination channel:** snowflake

### Links

- [PKG-4477](https://anaconda.atlassian.net/browse/PKG-4477) 
- [Upstream repository](https://github.com/TangleSpace/hydralit_components)

### Explanation of changes:

- creation of meta.yaml
- patched upstream setup.py. It mentions requiring `bs4`, but in order for `pip check` to pass we actually needed `beautifulsoup4` instead.
- added skip since `s390x` is missing streamlit


[PKG-4477]: https://anaconda.atlassian.net/browse/PKG-4477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ